### PR TITLE
Fix buster-sinon and buster-test dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "dependencies": {
         "referee": "~0.11",
         "referee-sinon": "~0.1",
-        "buster-sinon": "~0.1",
-        "buster-test": "~0.7",
+        "buster-sinon": "~0.6",
+        "buster-test": "~0.6",
         "stack-filter": "~0.1",
         "formatio": "~0.6",
         "sinon": "~1.6"


### PR DESCRIPTION
I tried installing buster-node 0.1.0 and it failed due to buster-sinon ~0.1 and buster-test ~0.6 dependencies which don't exist in npm registry.
I replaced them with buster-sinon ~0.6 and buster-test ~0.6 instead.

npm ERR! Error: No compatible version found: buster-sinon@'>=0.1.0- <0.2.0-'
npm ERR! Valid install targets:
npm ERR! ["0.5.0","0.5.1","0.6.0"]
